### PR TITLE
Add marketplace.json so the repo is installable via /plugin marketplace add

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,24 @@
+{
+  "name": "builder-skills",
+  "owner": {
+    "name": "Builder.io",
+    "url": "https://www.builder.io"
+  },
+  "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, efficient agent workflows, clear status recaps, and Agent-Native Plan modes.",
+  "plugins": [
+    {
+      "name": "builder-skills",
+      "source": "./",
+      "displayName": "Builder Skills",
+      "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, efficient agent workflows, clear status recaps, and Agent-Native Plan modes.",
+      "author": {
+        "name": "Builder.io",
+        "url": "https://www.builder.io"
+      },
+      "homepage": "https://github.com/BuilderIO/skills",
+      "repository": "https://github.com/BuilderIO/skills",
+      "license": "MIT",
+      "keywords": ["builder", "skills", "agent-workflows", "subagents"]
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -190,3 +190,25 @@ npx skills@latest add BuilderIO/skills --skill quick-recap
 That installer is useful for quick copying, but it does not add the managed
 `AGENTS.md` / `CLAUDE.md` instruction blocks or the PR Visual Recap GitHub
 Action that pair well with these skills.
+
+### Install as a Claude Code plugin
+
+This repo is also a [Claude Code plugin
+marketplace](https://code.claude.com/docs/en/plugin-marketplaces). To install
+all of the skills as a managed, updatable plugin, run these inside Claude Code:
+
+```sh
+/plugin marketplace add BuilderIO/skills
+/plugin install builder-skills@builder-skills
+```
+
+The skills are then namespaced under the plugin (for example,
+`/builder-skills:quick-recap`). Pull future updates with:
+
+```sh
+/plugin marketplace update builder-skills
+```
+
+This path does not add the managed `AGENTS.md` / `CLAUDE.md` instruction blocks
+or the PR Visual Recap GitHub Action; use the `npx @agent-native/skills`
+installer above if you want those.


### PR DESCRIPTION
## What

- Adds `.claude-plugin/marketplace.json` alongside the existing `.claude-plugin/plugin.json`, registering this repo as a single-plugin Claude Code **marketplace** that points at the `builder-skills` plugin already living at the repo root (`"source": "./"`).
- Documents the Claude Code plugin install path in `README.md` (new "Install as a Claude Code plugin" subsection).

## Why

The repo is already a valid Claude Code plugin (`plugin.json` is present), but Claude Code installs plugins through *marketplaces*. `/plugin marketplace add` looks for `.claude-plugin/marketplace.json`, which the repo doesn't have today — so the natural one-liner fails:

```
/plugin marketplace add BuilderIO/skills   # ❌ no marketplace.json found
```

With this file, users can install the skills as a managed, updatable plugin with the standard flow:

```
/plugin marketplace add BuilderIO/skills
/plugin install builder-skills@builder-skills
```

This is complementary to the existing `npx @agent-native/skills` installer — it just adds the native `/plugin` path for Claude Code users, with version tracking and `/plugin marketplace update` support.

## Details

- Marketplace `name` and the single plugin entry both use `builder-skills`; metadata mirrors `plugin.json` (description, author, homepage, repository, license, keywords).
- Plugin `source` is `"./"` — the plugin is the repo root, and relative sources resolve against the marketplace root (the directory containing `.claude-plugin/`).
- No `version` is set on the entry, matching `plugin.json`'s existing convention of relying on the git commit SHA for versioning.
- README gains an "Install as a Claude Code plugin" subsection under **Install**, noting the namespaced skill names (e.g. `/builder-skills:quick-recap`) and `/plugin marketplace update` for updates.

## Validation

`claude plugin validate` passes:

```
Validating marketplace manifest: .claude-plugin/marketplace.json
✔ Validation passed with warnings
```

(The lone warning is the intentional missing `version`, consistent with `plugin.json`.)