### PR TITLE
fix: update default agent-native source path

### DIFF
--- a/scripts/sync-agent-native-plan-skills.mjs
+++ b/scripts/sync-agent-native-plan-skills.mjs
@@ -8,7 +8,7 @@ const scriptPath = fileURLToPath(import.meta.url);
 const repoRoot = path.resolve(path.dirname(scriptPath), "..");
 const defaultFrameworkPath = path.resolve(
   repoRoot,
-  "../agent-native/framework",
+  "../agent-native",
 );
 
 const args = process.argv.slice(2);


### PR DESCRIPTION
Summary: Update the sync script's default Agent Native source path to match the current sibling checkout layout.\n\nWhy: The contributing docs clone BuilderIO/agent-native into ../agent-native, and the sync script already resolves that layout when the path is passed explicitly. Without AGENT_NATIVE_FRAMEWORK_PATH, however, npm run check defaulted to ../agent-native/framework, which does not exist in the current repo layout and caused the check to fail.\n\nWhat changed:\n- Changed the default source path from ../agent-native/framework to ../agent-native.\n\nHow to test:\n- npm run check\n- AGENT_NATIVE_FRAMEWORK_PATH=../agent-native npm run check\n- git diff --check\n\nNotes: No migrations or breaking changes.