### PR TITLE
Clarify local-files mode for visual-plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Small, composable skills for coding agents.
 
+Local visual-plan mode writes and serves MDX locally; it must not upload the plan to the hosted database first.
+
 ### Quick install recommended skills
 
 ```sh
@@ -39,7 +41,7 @@ changes start.
   <img alt="Visual plan review surface" src="media/visual-plan.png">
 </picture>
 
-Visual plans are MDX, customizable with your own components, and are viewed with the [Agent-Native plans app](https://www.agent-native.com/docs/template-plan). [Source here](https://github.com/BuilderIO/agent-native/)
+Visual plans are MDX, customizable with your own components, and are viewed with the [Agent-Native plans app](https://www.agent-native.com/docs/template-plan). In local-files mode, `/visual-plan` writes and serves MDX locally through a localhost bridge instead of uploading plan content to the hosted database. [Source here](https://github.com/BuilderIO/agent-native/)
 
 ### [`/visual-recap`](skills/visual-recap/README.md)
 

--- a/skills/visual-plan/README.md
+++ b/skills/visual-plan/README.md
@@ -3,7 +3,7 @@
 Turn ordinary implementation plans into rich interactive visual review surfaces.
 
 `/visual-plan` turns the plan an agent would normally write in chat into a
-human-optimized MDX document. Instead of a long wall of prose, reviewers get
+human-optimized MDX document. In local-files mode, it writes and serves the MDX locally rather than publishing to the hosted Plan database. Instead of a long wall of prose, reviewers get
 custom components built for understanding: architecture diagrams, wireframes,
 interactive prototypes, file maps, annotated code, OpenAPI-style API specs,
 visual schema maps, open questions, and comments.
@@ -65,7 +65,8 @@ actual codebase.
   and the browser editor.
 - **Local files only:** writes a local MDX folder, starts a localhost bridge,
   and opens the hosted Plan UI against that local source. No sharing, all local,
-  and no plan content is written to the hosted database.
+  and no plan content is written to the hosted database. The skill must not
+  create a hosted Plan first and export it back to local files.
 - **Self-hosted/custom URL:** connects the skill to your own Plan app or local
   development tunnel.
 

--- a/skills/visual-plan/SKILL.md
+++ b/skills/visual-plan/SKILL.md
@@ -119,22 +119,39 @@ skill's review discipline. Do not advise the user to skip `/visual-plan` because
 the default surface is hosted; choose the right Plan mode for the user's
 ownership, privacy, sharing, and branding needs.
 
-By default, create the plan via the Plan MCP connector and NEVER hand it over as
+First determine the Plan mode. If `AGENT_NATIVE_PLANS_MODE=local-files` is set,
+the installed skill/config selected local files, or the user asks for local-only /
+no hosted writes, use **Local-Files Privacy Mode** immediately: author the local
+MDX folder and run `plan local check` / `plan local serve` / `plan local verify`.
+Do not discover, call, import into, or publish through hosted Plan tools for that
+plan; a shareable `/plans/<id>` URL means the wrong mode was used.
+
+By default in hosted mode, create the plan via the Plan MCP connector and NEVER hand it over as
 inline chat content — no Markdown prose, ASCII sketch, table, or fenced
-wireframe. If the `plan` (or legacy `agent-native-plans`) tools are not visible,
+wireframe. First determine the Plan mode. If `AGENT_NATIVE_PLANS_MODE=local-files` is set,
+the installed skill/config selected local files, or the user asks for local-only /
+no hosted writes, use **Local-Files Privacy Mode** immediately: author the local
+MDX folder and run `plan local check` / `plan local serve` / `plan local verify`.
+Do not discover, call, import into, or publish through hosted Plan tools for that
+plan; a shareable `/plans/<id>` URL means the wrong mode was used.
+
+If the `plan` (or legacy `agent-native-plans`) tools are not visible,
 discover them through the host's `tool_search` first; if they are still missing,
 STOP and give the user the client-specific reconnect step rather than improvising
 an inline plan. Before publishing, or whenever a connector or auth error appears,
 READ `references/connection.md` in this skill directory — it is the single source
 of truth for the never-inline rule, connector discovery, and the per-client
-reconnect steps. Local-files privacy mode (after Tool Guidance) is the exception.
+reconnect steps. Local-files privacy mode is the exception.
 
 ## Core Workflow
 
 This section describes the default hosted Plan MCP workflow. If
-`AGENT_NATIVE_PLANS_MODE=local-files` is set, or the user asks for fully local
-files/no hosted Plan writes, use **Local-Files Privacy Mode** instead; carry
-forward only the code-research and plan-composition guidance here.
+`AGENT_NATIVE_PLANS_MODE=local-files` is set, the installed configuration selects
+local files, or the user asks for fully local files/no hosted Plan writes, use
+**Local-Files Privacy Mode** instead; carry forward only the code-research and
+plan-composition guidance here. In local-files mode, success is a checked local
+MDX folder plus a localhost bridge URL; do not upload first and then mirror or
+export the hosted plan locally.
 
 1. Follow the host agent's normal planning flow: inspect the codebase, delegate
    wide exploration when useful, gather the info needed, and ask native
@@ -371,6 +388,9 @@ artifacts, or `AGENT_NATIVE_PLANS_MODE=local-files` — do not call any hosted P
 tool except the schema-only `get-plan-blocks` catalog lookup. Author a local MDX
 folder and
 preview it with `plan local check` / `plan local serve` / `plan local verify`.
+Never call `create-visual-plan` / `create-ui-plan` and then export or link a
+hosted plan as a substitute for local-files mode; that uploads the content to the
+server and violates the local contract.
 Before using local-files mode, READ `references/local-files.md` in this skill
 directory — it is the single source of truth for the full contract (catalog
 lookup, MDX folder layout, the local bridge commands, and the hosted tools you

--- a/skills/visual-plan/references/local-files.md
+++ b/skills/visual-plan/references/local-files.md
@@ -23,10 +23,13 @@ The local-files contract:
   `npx @agent-native/core@latest recap collect-diff`, `scan`, and
   `build-prompt --local-files` helpers are safe — they operate on local files and
   do not write to the Plan database.
-- **Fetch the block catalog first** (it sends no plan content). Use the MCP
-  `get-plan-blocks` tool if it is already available, or run
-  `npx @agent-native/core@latest plan blocks --out plan-blocks.md` and read that
-  file before authoring MDX; it calls the public no-auth `get-plan-blocks` route.
+- **Fetch the block catalog first** (it sends no plan content). Prefer the local
+  CLI catalog command in local-files mode:
+  `npx @agent-native/core@latest plan blocks --out plan-blocks.md`, then read
+  that file before authoring MDX; it calls the public no-auth `get-plan-blocks`
+  route and never creates a plan. If the MCP `get-plan-blocks` tool is already
+  available you may use that schema-only lookup, but do not use tool discovery as
+  a prelude to hosted create/import/update tools for this local plan.
   Use `--format schema` when you need exact nested fields. If network access is
   unavailable, use the bundled `references/*.md` and rely on `plan local check` to
   catch invalid tags. Copy the catalog examples verbatim for the fields the
@@ -79,6 +82,18 @@ The local-files contract:
   `import-visual-plan-source`, `update-visual-plan`, `patch-visual-plan-source`,
   `get-plan-feedback`, `export-visual-plan`, `set-resource-visibility`, or any
   other hosted Plan tool — except the schema-only block-catalog lookup above.
+  Do not create a hosted plan and then export it into a local folder, and do not
+  report a `plan.agent-native.com/plans/<id>` link as the local preview. Those
+  are uploads to the Plan database, not local-files mode. If you accidentally
+  created a hosted artifact while local-files mode was required, treat it as a
+  mistake: stop using that artifact, recreate the plan from local MDX, and tell
+  the user the local contract was corrected.
+  Do not create a hosted plan and then export it into a local folder, and do not
+  report a `plan.agent-native.com/plans/<id>` link as the local preview. Those
+  are uploads to the Plan database, not local-files mode. If you accidentally
+  created a hosted artifact while local-files mode was required, treat it as a
+  mistake: stop using that artifact, recreate the plan from local MDX, and tell
+  the user the local contract was corrected.
 - **Feedback is file/chat feedback.** Update the MDX files directly, rerun
   `plan local check`, and rerun `serve` or `verify` when that preview path is
   available. Summarize the new local URL when one exists; otherwise summarize the

--- a/skills/visual-recap/references/local-files.md
+++ b/skills/visual-recap/references/local-files.md
@@ -23,10 +23,13 @@ The local-files contract:
   `npx @agent-native/core@latest recap collect-diff`, `scan`, and
   `build-prompt --local-files` helpers are safe — they operate on local files and
   do not write to the Plan database.
-- **Fetch the block catalog first** (it sends no plan content). Use the MCP
-  `get-plan-blocks` tool if it is already available, or run
-  `npx @agent-native/core@latest plan blocks --out plan-blocks.md` and read that
-  file before authoring MDX; it calls the public no-auth `get-plan-blocks` route.
+- **Fetch the block catalog first** (it sends no plan content). Prefer the local
+  CLI catalog command in local-files mode:
+  `npx @agent-native/core@latest plan blocks --out plan-blocks.md`, then read
+  that file before authoring MDX; it calls the public no-auth `get-plan-blocks`
+  route and never creates a plan. If the MCP `get-plan-blocks` tool is already
+  available you may use that schema-only lookup, but do not use tool discovery as
+  a prelude to hosted create/import/update tools for this local plan.
   Use `--format schema` when you need exact nested fields. If network access is
   unavailable, use the bundled `references/*.md` and rely on `plan local check` to
   catch invalid tags. Copy the catalog examples verbatim for the fields the
@@ -79,6 +82,18 @@ The local-files contract:
   `import-visual-plan-source`, `update-visual-plan`, `patch-visual-plan-source`,
   `get-plan-feedback`, `export-visual-plan`, `set-resource-visibility`, or any
   other hosted Plan tool — except the schema-only block-catalog lookup above.
+  Do not create a hosted plan and then export it into a local folder, and do not
+  report a `plan.agent-native.com/plans/<id>` link as the local preview. Those
+  are uploads to the Plan database, not local-files mode. If you accidentally
+  created a hosted artifact while local-files mode was required, treat it as a
+  mistake: stop using that artifact, recreate the plan from local MDX, and tell
+  the user the local contract was corrected.
+  Do not create a hosted plan and then export it into a local folder, and do not
+  report a `plan.agent-native.com/plans/<id>` link as the local preview. Those
+  are uploads to the Plan database, not local-files mode. If you accidentally
+  created a hosted artifact while local-files mode was required, treat it as a
+  mistake: stop using that artifact, recreate the plan from local MDX, and tell
+  the user the local contract was corrected.
 - **Feedback is file/chat feedback.** Update the MDX files directly, rerun
   `plan local check`, and rerun `serve` or `verify` when that preview path is
   available. Summarize the new local URL when one exists; otherwise summarize the


### PR DESCRIPTION
Updated visual-plan documentation to explicitly state that local-files mode must write and serve MDX locally instead of uploading to the hosted Plan database first. Added top-level README guidance so installers/users understand local visual-plan mode should not create hosted plans.