### PR TITLE
efficient-fable: add guidance for staying unblocked during execution

### DIFF
--- a/skills/efficient-fable/SKILL.md
+++ b/skills/efficient-fable/SKILL.md
@@ -35,6 +35,20 @@ Reserve Fable for:
 Prefer parallel subagents when the slices do not depend on each other. Keep
 blocking or highly coupled work local.
 
+## Staying Unblocked
+
+- Defer questions to the user until no other independent work remains: every
+  mid-plan stop stalls the slices that could keep moving. Batch open
+  questions for the end. Exception: ask immediately when the answer gates
+  every remaining slice or the next step is irreversible.
+- Don't sit blocked on a running subagent either: run subagents in the
+  background and spend the wait on orchestrator-side work — vetting earlier
+  results, planning the next slice.
+- Keep the build green even while changes are incomplete — leave unfinished
+  work stubbed or unwired rather than half-connected — so one blocked or
+  stalled slice does not block the others. If a slice breaks the build,
+  revert only its diff in the working copy.
+
 ## Handoff Packets
 
 Write delegated prompts as if the subagent has no useful chat context. Include
@@ -49,7 +63,8 @@ only the context it needs:
   look like when that is knowable.
 - Stop conditions: if the code does not match the prompt, a command fails after
   a reasonable retry, or the task needs out-of-scope files, stop and report
-  instead of improvising.
+  instead of improvising. Subagents should never pause to wait on user input;
+  they stop the task and report so the orchestrator stays unblocked.
 
 ## Vetting Delegated Work
 


### PR DESCRIPTION
Adds a "Staying Unblocked" section to the efficient-fable skill with three execution-time practices, and strengthens the existing stop-conditions guidance:

- **Defer user questions until no other independent work remains.** Every mid-plan stop stalls slices that could keep moving; batch open questions for the end. Exception: ask immediately when the answer gates every remaining slice or the next step is irreversible.
- **Don't sit blocked on a running subagent either** — run subagents in the background and spend the wait on orchestrator-side work (vetting earlier results, planning the next slice).
- **Keep the build green even with incomplete changes** — leave unfinished work stubbed or unwired rather than half-connected — so one blocked or stalled slice does not block the parallel ones. If a slice breaks the build, revert only its diff in the working copy.
- **Stop-conditions bullet in Handoff Packets:** make explicit that subagents never pause to wait on user input — they stop the task and report, keeping the orchestrator unblocked. (In Claude Code, Task-tool subagents cannot prompt the user anyway; this keeps the behavior explicit for other harnesses.)

## Potential further improvement (not in this PR)

A natural companion: before the orchestrator finally does block on a user question, write the full current state to a `HANDOFF.md` in the repo root — per-task status, decisions made and why, dead ends, the open question — so work can resume from a fresh context. Overwrite it on each update, never commit it, delete it when the task completes. This is more about orchestrator resumability than delegation efficiency, so it may fit better as a separate skill; happy to open a follow-up PR either way if there's interest.