### PR TITLE
docs: add preview link to Quick Recap skill

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,8 @@ Example yellow status:
 🟡 Code updated, set PROVIDER_WEBHOOK_SECRET before testing webhooks
 ```
 
+[See Quick Recap in a working agent](https://app.clawmama.run/skills/dt9dfr/hermes?locale=en-US&utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_builderio_skills_quick_recap)
+
 ### [`/read-the-damn-docs`](skills/read-the-damn-docs/README.md)
 
 Make agents web-search for authoritative docs before they guess from stale model

--- a/skills/quick-recap/README.md
+++ b/skills/quick-recap/README.md
@@ -45,6 +45,10 @@ Red means the agent is blocked on user input:
 🔴 Need the production API key to continue
 ```
 
+## Preview
+
+[See Quick Recap in a working agent](https://app.clawmama.run/skills/dt9dfr/hermes?locale=en-US&utm_source=github&utm_medium=issue&utm_campaign=skill_outreach_builderio_skills_quick_recap)
+
 ## Install
 
 ```sh


### PR DESCRIPTION
## Summary

Adds a preview link so readers can see the Quick Recap status convention in action before installing.

## Why

The red/yellow/green convention is a small but useful contract. An interactive preview lets potential users try it before committing to the managed install.

## What changed

- `README.md`: added preview link after examples in the `/quick-recap` section
- `skills/quick-recap/README.md`: added a Preview section between Output Examples and Install

## How to test

1. Visit the link in the preview section — it opens a live agent showing the convention
2. `npm run check:skills` passes (validates skill structure)

Closes #46