### PR TITLE
Add Rewind to the public skills catalog

### DIFF
--- a/.agents/skills/adding-a-skill/SKILL.md
+++ b/.agents/skills/adding-a-skill/SKILL.md
@@ -125,8 +125,10 @@ Keep the core and standalone `@agent-native/skills` MCP descriptors in sync.
   local MCP connection; public setup docs must use `@agent-native/skills` or
   `@agent-native/core`.
 - Plugin manifests that publish the whole `skills/` directory must carry an
-  always-on setup directive: Rewind stays unavailable until Core configures the
-  local MCP connection and `screen_memory_status` succeeds.
+  always-on setup directive: invoking Rewind with Clips absent asks permission
+  before opening the official install flow, never installs or enables capture
+  silently, and keeps Rewind unavailable until Core configures the local MCP
+  connection and `screen_memory_status` succeeds.
 
 ## Final Reporting
 

--- a/.agents/skills/adding-a-skill/SKILL.md
+++ b/.agents/skills/adding-a-skill/SKILL.md
@@ -30,6 +30,10 @@ Use this for public skill work in this repo. Keep ordinary skill changes in
 - **Plan skills:** `visual-plan` and `visual-recap` have generated/synced copies
   between this repo and `../agent-native/framework`. Do not treat them like a
   standalone prose folder.
+- **Rewind:** its canonical `SKILL.md` is generated from Agent Native because
+  the instructions and local Screen Memory tools share one privacy contract.
+  Keep the human README here; use `npm run sync:agent-native-skills` for the
+  generated skill instead of editing it by hand.
 
 ## Plain Public Skill Checklist
 
@@ -105,9 +109,9 @@ special install flags, inspect the framework before editing:
 
 Keep the core and standalone `@agent-native/skills` MCP descriptors in sync.
 
-## Plan Skill Sync Gotchas
+## Agent Native Skill Sync Gotchas
 
-`visual-plan` and `visual-recap` are special:
+`visual-plan`, `visual-recap`, and `rewind` are special:
 
 - Framework contains canonical/generated copies and Plan marketplace bundles.
 - This repo's `npm run check` compares those copies and can fail for drift
@@ -115,6 +119,14 @@ Keep the core and standalone `@agent-native/skills` MCP descriptors in sync.
 - When intentionally changing Plan skills, use the framework sync paths instead
   of hand-editing generated copies. Search the framework for
   `sync-plan-marketplace`, `sync-workspace-skills`, and `skills.sync.spec.ts`.
+- Rewind's `SKILL.md` is generated from
+  `packages/core/src/cli/skills-content/rewind-skill.ts`. Its public README is
+  preserved as an overlay. The plain-copy installer cannot configure Rewind's
+  local MCP connection; public setup docs must use `@agent-native/skills` or
+  `@agent-native/core`.
+- Plugin manifests that publish the whole `skills/` directory must carry an
+  always-on setup directive: Rewind stays unavailable until Core configures the
+  local MCP connection and `screen_memory_status` succeeds.
 
 ## Final Reporting
 

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,13 +4,13 @@
     "name": "Builder.io",
     "url": "https://www.builder.io"
   },
-  "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, efficient agent workflows, clear status recaps, and Agent-Native Plan modes.",
+  "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, local-first Rewind memory, efficient agent workflows, clear status recaps, and Agent-Native workflows.",
   "plugins": [
     {
       "name": "builder-skills",
       "source": "./",
       "displayName": "Builder Skills",
-      "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, efficient agent workflows, clear status recaps, and Agent-Native Plan modes.",
+      "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, local-first Rewind memory, efficient agent workflows, clear status recaps, and Agent-Native workflows.",
       "author": {
         "name": "Builder.io",
         "url": "https://www.builder.io"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "builder-skills",
   "displayName": "Builder Skills",
-  "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, efficient agent workflows, clear status recaps, and Agent-Native Plan modes.",
+  "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, local-first Rewind memory, efficient agent workflows, clear status recaps, and Agent-Native workflows.",
   "author": {
     "name": "Builder.io",
     "url": "https://www.builder.io"

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "builder-skills",
   "version": "0.0.0",
-  "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, efficient agent workflows, clear status recaps, and Agent-Native Plan modes.",
+  "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, local-first Rewind memory, efficient agent workflows, clear status recaps, and Agent-Native workflows.",
   "author": {
     "name": "Builder.io",
     "url": "https://www.builder.io"
@@ -13,7 +13,7 @@
   "interface": {
     "displayName": "Builder Skills",
     "shortDescription": "Builder skills for efficient agent workflows.",
-    "longDescription": "A small public skill collection for docs-first discipline, autonomous execution, cross-agent watchdogging and plan arbitration, efficient frontier-model orchestration, clear status recaps, and Agent-Native Plan workflows with hosted, local-files, or self-hosted modes.",
+    "longDescription": "A small public skill collection for docs-first discipline, autonomous execution, cross-agent watchdogging and plan arbitration, local-first Rewind screen memory, efficient frontier-model orchestration, clear status recaps, and Agent-Native workflows. Rewind requires separate local Clips Screen Memory MCP setup before use.",
     "developerName": "Builder.io",
     "category": "Productivity",
     "capabilities": ["Read", "Write"],
@@ -22,7 +22,8 @@
       "Use Builder Skills when a matching skill applies",
       "Web-search official docs before relying on memory for external APIs",
       "Install the quick recap status convention",
-      "Use efficient Fable orchestration"
+      "Use efficient Fable orchestration",
+      "Treat Rewind as unavailable until `npx @agent-native/core@latest skills add rewind --client codex --scope user --yes` configures the local Clips Screen Memory MCP and `screen_memory_status` succeeds"
     ]
   }
 }

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -13,7 +13,7 @@
   "interface": {
     "displayName": "Builder Skills",
     "shortDescription": "Builder skills for efficient agent workflows.",
-    "longDescription": "A small public skill collection for docs-first discipline, autonomous execution, cross-agent watchdogging and plan arbitration, local-first Rewind screen memory, efficient frontier-model orchestration, clear status recaps, and Agent-Native workflows. Rewind requires separate local Clips Screen Memory MCP setup before use.",
+    "longDescription": "A small public skill collection for docs-first discipline, autonomous execution, cross-agent watchdogging and plan arbitration, local-first Rewind screen memory, efficient frontier-model orchestration, clear status recaps, and Agent-Native workflows. Rewind asks permission to open the signed Clips Desktop install flow when the app is missing, then requires separate local Screen Memory MCP setup.",
     "developerName": "Builder.io",
     "category": "Productivity",
     "capabilities": ["Read", "Write"],
@@ -23,7 +23,8 @@
       "Web-search official docs before relying on memory for external APIs",
       "Install the quick recap status convention",
       "Use efficient Fable orchestration",
-      "Treat Rewind as unavailable until `npx @agent-native/core@latest skills add rewind --client codex --scope user --yes` configures the local Clips Screen Memory MCP and `screen_memory_status` succeeds"
+      "When Rewind is invoked without Clips Desktop, explain the prerequisite and ask permission before opening https://clips.agent-native.com/download; never install or enable capture silently",
+      "Treat Rewind as unavailable until Clips is running with Rewind enabled, `npx @agent-native/core@latest skills add rewind --client codex --scope user --yes` configures the local Screen Memory MCP, and `screen_memory_status` succeeds"
     ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           repository: BuilderIO/agent-native
           path: agent-native
-      - name: Check synced visual skills
+      - name: Check synced Agent Native skills
         env:
           AGENT_NATIVE_FRAMEWORK_PATH: ${{ github.workspace }}/agent-native
-        run: npm run check:plan-skills
+        run: npm run check:agent-native-skills

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,22 @@ jobs:
           node-version: "22"
       - name: Check public skill frontmatter
         run: npm run check:skills
+      - name: Resolve Agent Native source ref
+        id: agent-native-source
+        env:
+          CANDIDATE_REF: ${{ github.head_ref }}
+        run: |
+          source_ref=main
+          if [ -n "$CANDIDATE_REF" ] && git ls-remote --exit-code --heads \
+            https://github.com/BuilderIO/agent-native.git \
+            "refs/heads/$CANDIDATE_REF" >/dev/null; then
+            source_ref="$CANDIDATE_REF"
+          fi
+          echo "ref=$source_ref" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: BuilderIO/agent-native
+          ref: ${{ steps.agent-native-source.outputs.ref }}
           path: agent-native
       - name: Check synced Agent Native skills
         env:

--- a/.github/workflows/update-agent-native-plan-skills.yml
+++ b/.github/workflows/update-agent-native-plan-skills.yml
@@ -1,4 +1,4 @@
-name: Update Agent Native visual skills
+name: Update Agent Native exported skills
 
 on:
   workflow_dispatch:
@@ -9,22 +9,24 @@ on:
         type: string
         default: main
   repository_dispatch:
-    types: [agent-native-plan-skills-updated]
+    types:
+      - agent-native-public-skills-updated
+      - agent-native-plan-skills-updated
 
 permissions:
   contents: write
   pull-requests: write
 
 concurrency:
-  group: update-agent-native-plan-skills
+  group: update-agent-native-skills
   cancel-in-progress: true
 
 env:
-  UPDATE_BRANCH: automation/update-agent-native-plan-skills
+  UPDATE_BRANCH: automation/update-agent-native-skills
 
 jobs:
   update:
-    name: Refresh visual-plan and visual-recap
+    name: Refresh exported Agent Native skills
     runs-on: ubuntu-latest
     steps:
       - name: Generate app token
@@ -50,15 +52,15 @@ jobs:
         with:
           node-version: "22"
 
-      - name: Sync visual skills from Agent Native
+      - name: Sync exported skills from Agent Native
         env:
           AGENT_NATIVE_FRAMEWORK_PATH: ${{ github.workspace }}/.agent-native-source
-        run: npm run sync:agent-native-plan-skills
+        run: npm run sync:agent-native-skills
 
-      - name: Detect visual skill changes
+      - name: Detect exported skill changes
         id: diff
         run: |
-          if git diff --quiet -- skills/visual-plan skills/visual-recap; then
+          if git diff --quiet -- skills/visual-plan skills/visual-recap skills/rewind; then
             echo "changed=false" >> "$GITHUB_OUTPUT"
           else
             echo "changed=true" >> "$GITHUB_OUTPUT"
@@ -72,12 +74,12 @@ jobs:
           pr_number="$(gh pr list --head "$UPDATE_BRANCH" --state open --json number --jq '.[0].number // ""')"
           if [ -n "$pr_number" ]; then
             gh pr close "$pr_number" \
-              --comment "No Agent Native visual skill updates remain; closing this stale updater PR." \
+              --comment "No Agent Native exported skill updates remain; closing this stale updater PR." \
               --delete-branch
           fi
-          echo "Visual skills are already current."
+          echo "Exported Agent Native skills are already current."
 
-      - name: Check synced visual skills
+      - name: Check synced exported skills
         if: steps.diff.outputs.changed == 'true'
         env:
           AGENT_NATIVE_FRAMEWORK_PATH: ${{ github.workspace }}/.agent-native-source
@@ -89,8 +91,8 @@ jobs:
           git config user.name "builder-bot"
           git config user.email "builder-bot@users.noreply.github.com"
           git checkout -B "$UPDATE_BRANCH"
-          git add skills/visual-plan skills/visual-recap
-          git commit -m "chore: update Agent Native visual skills"
+          git add skills/visual-plan skills/visual-recap skills/rewind
+          git commit -m "chore: update Agent Native exported skills"
           git push --force-with-lease origin "$UPDATE_BRANCH"
 
       - name: Open or update PR
@@ -103,8 +105,8 @@ jobs:
           SOURCE_SHA: ${{ github.event.client_payload.sourceSha || inputs.sourceSha || 'main' }}
           SOURCE_RUN_URL: ${{ github.event.client_payload.sourceRunUrl }}
         run: |
-          cat > /tmp/update-visual-skills-pr.md <<EOF
-          This automated PR syncs \`visual-plan\` and \`visual-recap\` from Agent Native.
+          cat > /tmp/update-agent-native-skills-pr.md <<EOF
+          This automated PR syncs exported skills from Agent Native.
 
           Source:
           - Repository: \`$SOURCE_REPOSITORY\`
@@ -118,14 +120,14 @@ jobs:
           pr_number="$(gh pr list --head "$UPDATE_BRANCH" --state open --json number --jq '.[0].number // ""')"
           if [ -n "$pr_number" ]; then
             gh pr edit "$pr_number" \
-              --title "chore: update Agent Native visual skills" \
-              --body-file /tmp/update-visual-skills-pr.md
+              --title "chore: update Agent Native exported skills" \
+              --body-file /tmp/update-agent-native-skills-pr.md
           else
             gh pr create \
               --base "$BASE_BRANCH" \
               --head "$UPDATE_BRANCH" \
-              --title "chore: update Agent Native visual skills" \
-              --body-file /tmp/update-visual-skills-pr.md
+              --title "chore: update Agent Native exported skills" \
+              --body-file /tmp/update-agent-native-skills-pr.md
             pr_number="$(gh pr list --head "$UPDATE_BRANCH" --state open --json number --jq '.[0].number')"
           fi
           echo "number=$pr_number" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -33,9 +33,12 @@ what appeared on screen, or what happened just before the current task. It
 searches bounded local chapters, transcripts, OCR, and frames first; it is not a
 hosted recording archive and does not upload raw local media by default.
 
-Rewind requires macOS, a current Clips Desktop build, and a compatible agent
-with the local `clips-screen-memory` MCP connection. Follow the
-[Rewind setup and first-test guide](skills/rewind/README.md).
+Rewind requires macOS, the signed
+[Clips Desktop app](https://clips.agent-native.com/download), and a compatible
+agent with the local `clips-screen-memory` MCP connection. If you invoke Rewind
+before installing Clips, the skill asks permission to open the official install
+flow instead of silently installing capture software. Follow the [Rewind setup
+and first-test guide](skills/rewind/README.md).
 
 ### [`/visual-plan`](skills/visual-plan/README.md)
 
@@ -193,8 +196,9 @@ The installer walks you through the choices:
 - Whether to add the PR Visual Recap GitHub Action when `/visual-recap` is
   selected.
 - Whether to configure a compatible local agent connection when `/rewind` is
-  selected. Rewind requires Clips Desktop on macOS and remains disabled until
-  you turn it on in the Clips tray.
+  selected. The installer does not install Clips Desktop. If it is missing,
+  invoking Rewind asks permission to open the official download flow; capture
+  remains disabled until you turn it on in the Clips tray.
 
 Skip the picker with `--skill`:
 
@@ -237,7 +241,9 @@ The skills are then namespaced under the plugin (for example,
 ```
 
 The plugin installs Rewind's instructions only; it cannot configure the local
-Clips Screen Memory MCP connection. To use Rewind, also run:
+Clips Screen Memory MCP connection. When invoked, Rewind can ask permission to
+open the official Clips Desktop installer, but it must not install or enable
+capture silently. After Clips is installed and Rewind is enabled, also run:
 
 ```sh
 npx @agent-native/core@latest skills add rewind --client claude-code --scope user --yes

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ See the [full CLI docs below](#install).
 
 - [`/visual-plan`](#visual-plan) - Turn text plans into rich visual plans.
 - [`/visual-recap`](#visual-recap) - Turn diffs into interactive visual recaps.
+- [`/rewind`](#rewind) - Recover recent local screen context through Clips Desktop.
 - [`/agent-watchdog`](#agent-watchdog) - Audit another agent's work.
 - [`/plan-arbiter`](#plan-arbiter) - Compare competing plans and choose a direction.
 - [`/plow-ahead`](#plow-ahead) - Keep working through ordinary ambiguity.
@@ -24,6 +25,17 @@ See the [full CLI docs below](#install).
 - [`/read-the-damn-docs`](#read-the-damn-docs) - Check authoritative docs before guessing.
 
 ## Skill Details
+
+### [`/rewind`](skills/rewind/README.md)
+
+Use local Clips Rewind screen memory to recover a recent moment: what was said,
+what appeared on screen, or what happened just before the current task. It
+searches bounded local chapters, transcripts, OCR, and frames first; it is not a
+hosted recording archive and does not upload raw local media by default.
+
+Rewind requires macOS, a current Clips Desktop build, and a compatible agent
+with the local `clips-screen-memory` MCP connection. Follow the
+[Rewind setup and first-test guide](skills/rewind/README.md).
 
 ### [`/visual-plan`](skills/visual-plan/README.md)
 
@@ -164,8 +176,8 @@ Run the installer:
 npx @agent-native/skills@latest add
 ```
 
-The picker shows the full catalog, with `/visual-plan` and `/visual-recap` at
-the top and preselected by default. Toggle any additional skills you want.
+The picker shows the full catalog, with the recommended skills preselected.
+Toggle any additional skills you want.
 
 The installer walks you through the choices:
 
@@ -180,12 +192,16 @@ The installer walks you through the choices:
   selected skills have always-on guidance.
 - Whether to add the PR Visual Recap GitHub Action when `/visual-recap` is
   selected.
+- Whether to configure a compatible local agent connection when `/rewind` is
+  selected. Rewind requires Clips Desktop on macOS and remains disabled until
+  you turn it on in the Clips tray.
 
 Skip the picker with `--skill`:
 
 ```sh
 npx @agent-native/skills@latest add --skill quick-recap
 npx @agent-native/skills@latest add --skill visual-recap --with-github-action
+npx @agent-native/skills@latest add --skill rewind
 ```
 
 You can also use Vercel's `skills` CLI for a plain skill-folder copy:
@@ -193,6 +209,10 @@ You can also use Vercel's `skills` CLI for a plain skill-folder copy:
 ```sh
 npx skills@latest add BuilderIO/skills --skill quick-recap
 ```
+
+Do not use the plain-copy installer for Rewind: it cannot configure the local
+`clips-screen-memory` connection. Use `@agent-native/skills` or
+`@agent-native/core` for a complete Rewind setup.
 
 That installer is useful for quick copying, but it does not add the managed
 `AGENTS.md` / `CLAUDE.md` instruction blocks or the PR Visual Recap GitHub
@@ -215,6 +235,15 @@ The skills are then namespaced under the plugin (for example,
 ```sh
 /plugin marketplace update builder-skills
 ```
+
+The plugin installs Rewind's instructions only; it cannot configure the local
+Clips Screen Memory MCP connection. To use Rewind, also run:
+
+```sh
+npx @agent-native/core@latest skills add rewind --client claude-code --scope user --yes
+```
+
+Treat Rewind as unavailable until `screen_memory_status` succeeds.
 
 This path does not add the managed `AGENTS.md` / `CLAUDE.md` instruction blocks
 or the PR Visual Recap GitHub Action; use the `npx @agent-native/skills`

--- a/package.json
+++ b/package.json
@@ -3,12 +3,12 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, efficient frontier-model orchestration, clear status recaps, and Agent Native Plan workflows.",
+  "description": "Public Builder skills for docs-first discipline, autonomous execution, cross-agent review, local-first Rewind memory, efficient frontier-model orchestration, clear status recaps, and Agent Native workflows.",
   "license": "MIT",
   "scripts": {
     "check:skills": "node scripts/check-skill-frontmatter.mjs",
-    "check:plan-skills": "node scripts/sync-agent-native-plan-skills.mjs --check",
-    "sync:agent-native-plan-skills": "node scripts/sync-agent-native-plan-skills.mjs",
-    "check": "npm run check:skills && npm run check:plan-skills"
+    "check:agent-native-skills": "node scripts/sync-agent-native-skills.mjs --check",
+    "sync:agent-native-skills": "node scripts/sync-agent-native-skills.mjs",
+    "check": "npm run check:skills && npm run check:agent-native-skills"
   }
 }

--- a/scripts/sync-agent-native-skills.mjs
+++ b/scripts/sync-agent-native-skills.mjs
@@ -17,6 +17,7 @@ const sourceArg = args.find((arg) => arg !== "--check");
 
 const requestedSource =
   sourceArg ||
+  process.env.AGENT_NATIVE_SKILLS_SOURCE ||
   process.env.AGENT_NATIVE_PLAN_SKILLS_SOURCE ||
   process.env.AGENT_NATIVE_FRAMEWORK_PATH ||
   defaultFrameworkPath;
@@ -80,6 +81,37 @@ function resolveSources(sourcePath) {
   return match;
 }
 
+async function readRewindSkill(sourcePath) {
+  const rewindSource = path.join(
+    path.resolve(sourcePath),
+    "packages/core/src/cli/skills-content/rewind-skill.ts",
+  );
+  if (!existsSync(rewindSource)) {
+    throw new Error(`Could not find canonical Rewind skill at ${rewindSource}`);
+  }
+
+  const source = await readFile(rewindSource, "utf8");
+  const match = /export const REWIND_SKILL_MD = `([\s\S]*?)`;\s*$/.exec(source);
+  if (!match) {
+    throw new Error(`Could not read REWIND_SKILL_MD from ${rewindSource}`);
+  }
+
+  return {
+    source: rewindSource,
+    content: decodeStaticTemplateLiteral(match[1], rewindSource),
+  };
+}
+
+function decodeStaticTemplateLiteral(content, source) {
+  if (content.includes("${")) {
+    throw new Error(`Rewind skill interpolation is not supported in ${source}`);
+  }
+  if (/\\(?![\\`$])/.test(content)) {
+    throw new Error(`Rewind skill contains an unsupported escape in ${source}`);
+  }
+  return content.replace(/\\([\\`$])/g, "$1");
+}
+
 async function copySkill(name, sourceDir) {
   const destination = path.join(destinationRoot, name);
   const preservedDocs = [];
@@ -103,6 +135,30 @@ async function copySkill(name, sourceDir) {
 
   console.log(`Synced ${name}`);
   console.log(`  from ${sourceDir}`);
+  console.log(`  to   ${destination}`);
+}
+
+async function copyGeneratedSkill(name, source) {
+  const destination = path.join(destinationRoot, name);
+  const preservedDocs = [];
+
+  for (const rel of publicDocOverlays) {
+    const docPath = path.join(destination, rel);
+    if (existsSync(docPath)) {
+      preservedDocs.push([rel, await readFile(docPath, "utf8")]);
+    }
+  }
+
+  await rm(destination, { recursive: true, force: true });
+  await mkdir(destination, { recursive: true });
+  await writeFile(path.join(destination, "SKILL.md"), source.content);
+
+  for (const [rel, body] of preservedDocs) {
+    await writeFile(path.join(destination, rel), body);
+  }
+
+  console.log(`Synced ${name}`);
+  console.log(`  from ${source.source}`);
   console.log(`  to   ${destination}`);
 }
 
@@ -148,16 +204,30 @@ async function assertSkillCurrent(name, sourceDir) {
   console.log(`${name} is current`);
 }
 
+async function assertGeneratedSkillCurrent(name, source) {
+  const destination = path.join(destinationRoot, name, "SKILL.md");
+  if (!existsSync(destination)) {
+    throw new Error(`${name} is missing at ${destination}`);
+  }
+  if ((await readFile(destination, "utf8")) !== source.content) {
+    throw new Error(`${name}/SKILL.md is out of sync`);
+  }
+  console.log(`${name} is current`);
+}
+
 try {
   const sources = resolveSources(requestedSource);
+  const rewind = await readRewindSkill(requestedSource);
 
   console.log(`Using ${sources.label}`);
   if (check) {
     await assertSkillCurrent("visual-plan", sources.visualPlan);
     await assertSkillCurrent("visual-recap", sources.visualRecap);
+    await assertGeneratedSkillCurrent("rewind", rewind);
   } else {
     await copySkill("visual-plan", sources.visualPlan);
     await copySkill("visual-recap", sources.visualRecap);
+    await copyGeneratedSkill("rewind", rewind);
   }
 } catch (error) {
   console.error(error instanceof Error ? error.message : String(error));

--- a/skills/rewind/README.md
+++ b/skills/rewind/README.md
@@ -1,0 +1,78 @@
+# /rewind
+
+Recover a recent local moment from Clips Desktop without turning your desktop
+into a hosted archive. Rewind helps an agent find what you just said, saw, or
+did by searching bounded local chapters first, then the smallest useful range
+of local transcript, OCR, or frame context.
+
+## Requirements
+
+- macOS with a current [Clips Desktop](https://www.agent-native.com/docs/template-clips)
+  build.
+- A compatible coding-agent host: Codex, Claude Code, Cursor, OpenCode, GitHub
+  Copilot, or Cowork.
+- Rewind enabled in the Clips tray. It is disabled by default, and macOS may
+  request the capture permissions that match the mode you choose.
+
+## Privacy And Retention
+
+Rewind stores its rolling buffer locally. You choose the capture mode,
+excluded/private apps, and retention in Clips. The skill searches local screen
+memory through the `clips-screen-memory` MCP connection; it does not expose
+archive paths or upload raw frames, audio, transcripts, OCR, or indexes.
+
+If local evidence is not enough, an agent can propose the smallest timestamp
+range for a bounded private Clip handoff. That escalation is explicit; it is not
+a hosted fallback wearing a fake mustache.
+
+## Set Up Rewind
+
+The recommended path is in Clips Desktop:
+
+1. Open the Clips tray, turn on **Rewind**, and select **Visuals** or
+   **Visuals + audio**.
+2. Complete the macOS permission prompts.
+3. Click **Set up your agent** on the Rewind card and paste the copied prompt
+   into your agent. It installs the reusable skill and the local MCP connection
+   together.
+4. Restart the agent only if it cannot reload MCP servers in place.
+
+To repair or configure a connection directly, run this in a terminal with the
+matching client name:
+
+```sh
+npx -y @agent-native/core@latest skills add rewind --client codex --scope user --yes
+```
+
+The public skills installer also supports Rewind:
+
+```sh
+npx @agent-native/skills@latest add --skill rewind
+```
+
+Both advertised paths must install the local `clips-screen-memory` connection;
+if either reports that it cannot do so, treat setup as incomplete rather than
+using Rewind as prose-only instructions.
+
+## First Test
+
+Ask your agent: **“Look at Rewind.”** A working setup calls
+`screen_memory_status` first and reports that Rewind is enabled and unpaused.
+For a recent moment, it searches chapters before reading the smallest useful
+local context range.
+
+## Repair
+
+If Rewind is unavailable:
+
+- Confirm Clips Desktop is current, running on macOS, and Rewind is enabled in
+  its tray settings.
+- Run the direct command above with a supported `--client` value, then restart
+  the agent if it does not reload MCP configuration.
+- Update to a current Node runtime before retrying the installer.
+- If your host is not listed above, it is not yet a supported Rewind MCP host;
+  do not point it at a hosted endpoint as a substitute.
+
+See the [Clips documentation](https://www.agent-native.com/docs/template-clips)
+and [Agent Native source](https://github.com/BuilderIO/agent-native) for the
+current product and implementation details.

--- a/skills/rewind/README.md
+++ b/skills/rewind/README.md
@@ -7,8 +7,8 @@ of local transcript, OCR, or frame context.
 
 ## Requirements
 
-- macOS with a current [Clips Desktop](https://www.agent-native.com/docs/template-clips)
-  build.
+- macOS with the current signed [Clips Desktop](https://clips.agent-native.com/download)
+  app installed and running.
 - A compatible coding-agent host: Codex, Claude Code, Cursor, OpenCode, GitHub
   Copilot, or Cowork.
 - Rewind enabled in the Clips tray. It is disabled by default, and macOS may
@@ -27,15 +27,24 @@ a hosted fallback wearing a fake mustache.
 
 ## Set Up Rewind
 
-The recommended path is in Clips Desktop:
+You can invoke `/rewind` before doing any setup. If Clips Desktop is missing,
+the agent should explain the prerequisite and ask permission before opening the
+official download page. It must not silently download or install Clips, bypass
+Gatekeeper, accept macOS permission prompts, or enable capture for you.
 
-1. Open the Clips tray, turn on **Rewind**, and select **Visuals** or
+After permission, a capable agent can open the official install flow. If the
+agent cannot control native UI, it should give you the direct
+[Clips Desktop download link](https://clips.agent-native.com/download) and wait
+for you to finish. Then:
+
+1. Install and launch Clips Desktop.
+2. Open the Clips tray, turn on **Rewind**, and select **Visuals** or
    **Visuals + audio**.
-2. Complete the macOS permission prompts.
-3. Click **Set up your agent** on the Rewind card and paste the copied prompt
+3. Complete the macOS permission prompts yourself.
+4. Click **Set up your agent** on the Rewind card and paste the copied prompt
    into your agent. It installs the reusable skill and the local MCP connection
    together.
-4. Restart the agent only if it cannot reload MCP servers in place.
+5. Restart the agent only if it cannot reload MCP servers in place.
 
 To repair or configure a connection directly, run this in a terminal with the
 matching client name:
@@ -52,7 +61,8 @@ npx @agent-native/skills@latest add --skill rewind
 
 Both advertised paths must install the local `clips-screen-memory` connection;
 if either reports that it cannot do so, treat setup as incomplete rather than
-using Rewind as prose-only instructions.
+using Rewind as prose-only instructions. These commands configure the agent;
+they do not install or enable Clips Desktop.
 
 ## First Test
 
@@ -65,6 +75,8 @@ local context range.
 
 If Rewind is unavailable:
 
+- If Clips Desktop is missing, ask the agent to open the official
+  [download page](https://clips.agent-native.com/download), or open it yourself.
 - Confirm Clips Desktop is current, running on macOS, and Rewind is enabled in
   its tray settings.
 - Run the direct command above with a supported `--client` value, then restart

--- a/skills/rewind/SKILL.md
+++ b/skills/rewind/SKILL.md
@@ -13,6 +13,38 @@ metadata:
 Use Clips Rewind as local screen memory. Start broad enough to find the right
 moment, then read only the smallest relevant range.
 
+## First-Run Setup
+
+Call `screen_memory_status` before assuming Rewind is ready. If the tool is
+unavailable, do not stop at a missing-tool error and do not silently install
+anything:
+
+1. Explain that Rewind requires the signed Clips Desktop app on macOS plus a
+   local agent connection.
+2. Ask whether Clips is installed, or use a non-mutating native application
+   lookup when the host supports one. Do not inspect Clips' app-data folders.
+   If Clips is absent or its presence cannot be confirmed, ask permission
+   before opening or downloading anything: “Clips Desktop is required for
+   Rewind. Would you like me to open the official installer and guide you
+   through setup?”
+3. Only after affirmative permission, open
+   `https://clips.agent-native.com/download` in the user's browser. Complete
+   native installation steps only when the current host can safely do so and
+   the user explicitly permitted them. Never bypass Gatekeeper, accept macOS
+   permission prompts, or enable screen/audio capture on the user's behalf.
+4. If native UI control is unavailable, return the download link and wait for
+   the user to confirm that Clips is installed and running.
+5. Ask the user to enable Rewind in the Clips tray and choose the intended
+   capture mode. Then configure the local connection with:
+
+   `npx -y @agent-native/core@latest skills add rewind --client <client> --scope user --yes`
+
+   Replace `<client>` with the current compatible host: `codex`,
+   `claude-code`, `cursor`, `opencode`, `github-copilot`, or `cowork`.
+6. Restart the host only if it cannot reload MCP servers in place, then retry
+   `screen_memory_status`. Do not claim setup succeeded until it reports
+   Rewind enabled and unpaused.
+
 ## Retrieval Flow
 
 1. Call `screen_memory_status` first. If the newest segment is still open,
@@ -41,11 +73,11 @@ moment, then read only the smallest relevant range.
   bypass the Screen Memory MCP broker.
 - Do not upload frames returned by local Screen Memory tools.
 - Treat foreground apps and chapter labels as evidence, not proof of intent.
-- If the Screen Memory MCP is missing, explain that the one-time setup needs to
-  be repaired with:
+- If Clips is installed and Rewind is enabled but the Screen Memory MCP is
+  missing, explain that only the agent connection needs repair with:
 
   `npx -y @agent-native/core@latest skills add rewind --client <client> --scope user --yes`
 
-  Replace `<client>` with the current compatible host: `codex`,
-  `claude-code`, `cursor`, `opencode`, `github-copilot`, or `cowork`.
   Ask the user to restart the host if it cannot reload MCP servers in place.
+- Never conflate installing Clips Desktop with installing the skill/MCP
+  connection, and never claim either succeeded without direct evidence.

--- a/skills/rewind/SKILL.md
+++ b/skills/rewind/SKILL.md
@@ -1,0 +1,51 @@
+---
+name: rewind
+description: >-
+  Retrieve recent local Clips Rewind context when the user says "Look at
+  Rewind," asks what just happened, or refers to something they recently said
+  or saw.
+metadata:
+  visibility: exported
+---
+
+# Rewind
+
+Use Clips Rewind as local screen memory. Start broad enough to find the right
+moment, then read only the smallest relevant range.
+
+## Retrieval Flow
+
+1. Call `screen_memory_status` first. If the newest segment is still open,
+   wait for it to finalize rather than substituting an older segment.
+2. Search `screen_memory_search_chapters` before requesting raw recent
+   context. Use the user's words, the visible app or project, and the likely
+   time range as clues.
+3. If several chapters plausibly match, show the candidates and ask which one
+   the user means. Do not blend separate workstreams together.
+4. Read the smallest useful range with `screen_memory_recent_context`.
+   Restate what you recovered before acting, and flag transcription or coverage
+   uncertainty.
+5. Use `screen_memory_frame_at` for one exact visual moment or
+   `screen_memory_contact_sheet` to scan a bounded range. Prefer local frames
+   before escalating to cloud processing.
+6. Request the smallest relevant timestamp range through Clips' bounded private
+   Clip handoff only when local text and frames are insufficient, such as
+   garbled speech, important motion, dense analysis, or a Clip the user wants
+   to keep and query later.
+
+## Boundaries
+
+- Rewind recordings, screenshots, audio, transcripts, OCR, and indexes remain
+  local unless the user explicitly asks for a bounded Clip handoff.
+- Do not reveal archive filesystem paths, crawl Clips' app-data folders, or
+  bypass the Screen Memory MCP broker.
+- Do not upload frames returned by local Screen Memory tools.
+- Treat foreground apps and chapter labels as evidence, not proof of intent.
+- If the Screen Memory MCP is missing, explain that the one-time setup needs to
+  be repaired with:
+
+  `npx -y @agent-native/core@latest skills add rewind --client <client> --scope user --yes`
+
+  Replace `<client>` with the current compatible host: `codex`,
+  `claude-code`, `cursor`, `opencode`, `github-copilot`, or `cowork`.
+  Ask the user to restart the host if it cannot reload MCP servers in place.


### PR DESCRIPTION
## Summary

Add Rewind to the public Builder skills catalog while keeping its executable instructions synchronized from Agent Native and its local Clips connection fail-closed.

## Why

Rewind is not useful as a copied prompt alone. It reads recent local context through Clips Desktop and a local Model Context Protocol (MCP) connection. Publishing only `SKILL.md` would let users discover the workflow but leave the agent unable to call its tools; first-time users could also reach a missing-tool error without a safe route to install Clips.

Agent Native therefore remains canonical for the generated skill and local installer. This repository owns public discovery and a human-facing README that explains setup, privacy, and repair.

## What changed

- Add the generated `skills/rewind/SKILL.md` and preserve `skills/rewind/README.md` as a public documentation overlay.
- Generalize the existing Visual Plan/Visual Recap sync script and workflow to include exported Agent Native skills.
- Add Rewind to the root catalog and Claude/Codex plugin metadata.
- Direct complete installs to `@agent-native/skills` or `@agent-native/core`; plain-copy and whole-directory plugin paths explain that they cannot configure the local MCP connection by themselves.
- Require invocation-time consent before opening the official Clips installer and keep Rewind unavailable until Core configures the connection and `screen_memory_status` succeeds.
- Let CI validate a trusted same-named Agent Native branch when the two companion PRs are open together, otherwise fall back to Agent Native `main`.
- Accept both legacy and new repository-dispatch events during the producer/consumer transition under one cancel-in-progress concurrency group.

## How to test

- **Passed:** `npm run check` against the paired Agent Native branch, proving skill frontmatter validity and exact synchronization for Visual Plan, Visual Recap, and Rewind.
- **Passed:** PR CI `check` on head `d668717`, using the trusted companion branch, plus GitGuardian's secret scan.
- **Passed:** plugin JSON parsing and an HTTP 200 check for `https://clips.agent-native.com/download`.
- **Passed:** independent technical review found no material synchronization, installer-contract, or workflow security defect.
- **Blocked:** end-to-end clean-profile macOS acceptance still requires a runnable branch-built Agent Native CLI, a signed Clips installer, and a profile where Clips is absent. The available machine could not supply that state without touching an existing installation, so the frozen H1–H10 journey remains a pre-merge gate.

For a local sync check:

```sh
AGENT_NATIVE_FRAMEWORK_PATH=/path/to/agent-native npm run check
```

## Notes

- No dependencies, schema migrations, credentials, or data migrations are added.
- Rewind remains disabled by default in Clips. Neither this repository nor its plugin installs Clips, grants capture permissions, or enables screen/audio capture.
- `skills/rewind/SKILL.md` is generated; edit the canonical Agent Native source and run `npm run sync:agent-native-skills`. The public README is intentionally maintained here.
- The companion producer sends the legacy sync event first and the new event second, so either PR may merge first without losing the synchronization request.

## Review focus

- Is the boundary between the generated skill and public README understandable and maintainable?
- Do every public installation path and plugin surface accurately distinguish copying instructions from configuring the local MCP connection?
- Is the same-named-branch CI lookup constrained to trusted `BuilderIO/agent-native` refs, with a safe `main` fallback?
- Do the dual event names and shared concurrency group make the cross-repository transition idempotent?

## Companion PR

Canonical skill and installer: https://github.com/BuilderIO/agent-native/pull/2345
