### PR TITLE
docs: document Cowork plugin installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,7 +246,27 @@ That installer is useful for quick copying, but it does not add the managed
 `AGENTS.md` / `CLAUDE.md` instruction blocks or the PR Visual Recap GitHub
 Action that pair well with these skills.
 
-### Install as a Claude Code plugin
+### Install in Claude Cowork
+
+This repo is also a Claude plugin marketplace for Cowork. To install the
+shareable, updatable plugin in Cowork:
+
+1. Open `Customize` > `Plugins` > `Add marketplace`.
+2. Enter `BuilderIO/skills` (or `https://github.com/BuilderIO/skills`).
+3. Install `Builder Skills` and enable the `webmcp` skill.
+
+Invoke the installed skill with its plugin namespace:
+
+```text
+/builder-skills:webmcp slides inspect the current screen without editing
+```
+
+For Team and Enterprise workspaces, an organization admin can provision the
+marketplace or plugin for everyone. Cowork does not currently expose a
+supported CLI command for installing an account-level plugin; the marketplace
+is shared through Git, while each Cowork user installs it from `Customize`.
+
+### Install in Claude Code
 
 This repo is also a [Claude Code plugin
 marketplace](https://code.claude.com/docs/en/plugin-marketplaces). To install

--- a/skills/webmcp/README.md
+++ b/skills/webmcp/README.md
@@ -63,3 +63,21 @@ explicit request to use UI automation for that operation changes this.
 ```sh
 npx @agent-native/skills@latest add --skill webmcp
 ```
+
+## Install in Claude Cowork
+
+For a shareable Cowork install, add this repository as a Claude plugin
+marketplace:
+
+1. Open `Customize` > `Plugins` > `Add marketplace` in Cowork.
+2. Enter `BuilderIO/skills` (or `https://github.com/BuilderIO/skills`).
+3. Install `Builder Skills` and enable `webmcp`.
+
+The plugin skill is namespaced, so invoke it as:
+
+```text
+/builder-skills:webmcp slides inspect the current screen without editing
+```
+
+The `npx` command above installs a plain local skill for supported agent
+clients. It does not add a skill to a Claude Cowork account.


### PR DESCRIPTION
## Summary

- Document the existing `builder-skills` Claude plugin as the shareable Cowork marketplace path.
- Show Cowork marketplace installation and the namespaced `/builder-skills:webmcp` invocation.
- Clarify that the `npx` installer is for local agent clients, not Cowork account sync.
- Note the Team and Enterprise organization-managed provisioning path.

## Validation

- `claude plugin validate .` passed with the existing optional-version warning.
- `npm run check:skills` passed.
- `git diff --check` passed.

## Notes

The full `npm run check` remains environment-blocked in this standalone checkout because its existing sync script defaults to `/Users/steve/.codex/worktrees/agent-native/framework`, which is not present here.
